### PR TITLE
タスク削除時の即時反映対応 #18

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -81,7 +81,8 @@ class MyHomePage extends StatelessWidget {
                             onPressed: (context) {
                               DataManager.deleteTask(
                                   'admin', tasks[index].docId);
-                              // tasks.removeAt(index);
+                              tasks.removeAt(index);
+                              model.notify();
                             },
                             flex: 2,
                             backgroundColor: const Color(0xFFFE4A49),

--- a/lib/model/main_model.dart
+++ b/lib/model/main_model.dart
@@ -14,4 +14,9 @@ class MainModel extends ChangeNotifier {
     this.tasks = tasks;
     notifyListeners();
   }
+
+  /// notifyListeners を実行します。
+  void notify() {
+    notifyListeners();
+  }
 }


### PR DESCRIPTION
タスクの削除時にTaskModelのnotifyListeners()を呼び出し、リストを再ビルドすることで
削除内容を即時にリストに反映するようにしました。